### PR TITLE
Fixing screen size

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -4,7 +4,8 @@ String analyticsUrl = "https://youranalyticsurl.com";
 const String analyticsName = "yourappname"; // this is actually the site name
 
 void main() {
-  Plausible plausible = Plausible(analyticsUrl, analyticsName);
+  Plausible plausible =
+      Plausible(analyticsUrl, analyticsName, screenWidth: 384);
   // Send goal
   plausible.event(name: 'Device', props: {
     'app_version': 'v1.0.0',

--- a/lib/plausible_analytics.dart
+++ b/lib/plausible_analytics.dart
@@ -9,12 +9,12 @@ class Plausible {
   String serverUrl;
   String userAgent;
   String domain;
-  String screenWidth;
+  int screenWidth;
   bool enabled = true;
 
   /// Constructor
   Plausible(this.serverUrl, this.domain,
-      {this.userAgent = "", this.screenWidth = ""});
+      {this.userAgent = "", required this.screenWidth});
 
   /// Post event to plausible
   Future<int> event(

--- a/test/plausible_analytics_test.dart
+++ b/test/plausible_analytics_test.dart
@@ -6,7 +6,7 @@ const String domain = "example.com";
 const String name = "pageview";
 const String url = "app://localhost/test";
 const String referrer = "app://localhost/referrer";
-const String screenWidth = "1000x1000";
+const int screenWidth = 384;
 
 void main() {
   test('make plausible event call with pageview', () async {


### PR DESCRIPTION
Changing data type of screenWidth attribute to fix Plausible tracker. 

The previously type was string, but the expected type for Plausible Analytics server is Intenger. 
Sending this value as string makes the identification of devices interpret mobile access as desktop. 